### PR TITLE
Google Analytics/Tag Manager Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Here are the changes we make, via deface, in the default Solidus views as part o
 
 
 - In `spree/layouts/spree_application.html.erb`
+  - Insert `<%= render 'solidus_seo/analytics' %>` just before `</head>`.
   - Insert `<%= dump_jsonld %>` just before the `</body>` closing tag.
 
 
@@ -63,6 +64,7 @@ At this point, assuming you're using the default Solidus views and this extensio
   - Breadcrumb jsonld markup in your taxon pages.
   - ItemList jsonld markup in your paginated product pages.
   - Site-wide default paperclip image optimization (through image_optim)
+  - Google Analytics/Tag Manager page views + ecommerce integrations via presence of `GOOGLE_TAG_MANAGER_ID` and `GOOGLE_ANALYTICS_ID` environment variables, respectively (only one integration should be enabled at a time).
 
 ### Models
 

--- a/app/controllers/spree/store_controller_decorator.rb
+++ b/app/controllers/spree/store_controller_decorator.rb
@@ -1,4 +1,4 @@
 Spree::StoreController.class_eval do
-  include SolidusSeo::MetaDataBuilder
-  helper SolidusSeo::Jsonld::TagHelper
+  include ::SolidusSeo::MetaDataBuilder
 end
+

--- a/app/views/solidus_seo/_analytics.html.erb
+++ b/app/views/solidus_seo/_analytics.html.erb
@@ -1,0 +1,74 @@
+<%
+if ENV.values_at('GOOGLE_TAG_MANAGER_ID', 'GOOGLE_ANALYTICS_ID').any? &&
+  @order && order_just_completed?(@order)
+
+  shared_order_data = {
+      affiliation: current_store.name,
+      currency: @order.currency,
+      tax: @order.tax_total,
+      shipping: @order.ship_total,
+  }
+
+  purchased_items = @order.line_items.map do |line_item|
+      variant = line_item.variant
+      next unless variant
+
+      {
+          id: variant.sku,
+          name: variant.name,
+          price: line_item.total,
+          variant: variant.options_text,
+          quantity: line_item.quantity,
+      }
+  end.compact
+end
+
+if ENV['GOOGLE_TAG_MANAGER_ID'].present?
+%>
+<script>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= ENV['GOOGLE_TAG_MANAGER_ID'] %>');
+
+    window.dataLayer = window.dataLayer || [];
+
+    <% if @order && order_just_completed?(@order) %>
+        let purchaseData = Object.assign({}, <%= raw shared_order_data.json %>, {
+            'transaction_id': '<%= @order.number %>',
+            'value': '<%= @order.total %>',
+            'items': <%= raw purchased_items.to_json %>
+        });
+
+        gtag('event', 'purchase', purchaseData);
+    <% end %>
+</script>
+
+<% elsif ENV['GOOGLE_ANALYTICS_ID'].present? %>
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GOOGLE_ANALYTICS_ID'] %>"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '<%= ENV['GOOGLE_ANALYTICS_ID'] %>');
+
+    <% if @order && order_just_completed?(@order) %>
+        let orderData = Object.assign({}, <%= raw shared_order_data.to_json %>, {
+            'id': '<%= j @order.number %>', // Transaction ID. Required for purchases and refunds.
+            'revenue': '<%= @order.total %>', // Total transaction value (incl. tax and shipping)
+            'coupon': '' // TODO: Add coupon code if present
+        });
+
+        window.dataLayer.push({
+            'ecommerce': {
+                'purchase': {
+                    'actionField': orderData,
+                    'products': <%= raw purchased_items.to_json %>
+                }
+            }
+        });
+    <% end %>
+</script>
+<% end %>

--- a/lib/generators/solidus_seo/install/install_generator.rb
+++ b/lib/generators/solidus_seo/install/install_generator.rb
@@ -33,6 +33,7 @@ module SolidusSeo
           copy_file 'insert_display_meta_tags_helper.html.erb.deface', 'app/overrides/spree/shared/_head/insert_display_meta_tags_helper.html.erb.deface'
           copy_file 'remove_original_title_tag.deface', 'app/overrides/spree/shared/_head/remove_original_title_tag.deface'
           copy_file 'insert_product_list_helper.html.erb.deface', 'app/overrides/spree/shared/_products/insert_product_list_helper.html.erb.deface'
+          copy_file 'insert_analytics_in_layout.html.erb.deface', 'app/overrides/spree/layouts/spree_application/insert_analytics_in_layout.html.erb.deface'
         end
       end
     end

--- a/lib/generators/solidus_seo/install/templates/insert_analytics_in_layout.html.erb.deface
+++ b/lib/generators/solidus_seo/install/templates/insert_analytics_in_layout.html.erb.deface
@@ -1,0 +1,4 @@
+<!--
+insert_bottom %{head}
+-->
+<%= render 'solidus_seo/analytics' %>

--- a/lib/solidus_seo/engine.rb
+++ b/lib/solidus_seo/engine.rb
@@ -20,6 +20,10 @@ module SolidusSeo
       end
     end
 
+    initializer "solidus_seo.view_helpers" do
+      ActiveSupport.on_load(:action_view) { ActionView::Base.send :include, Jsonld::TagHelper }
+    end
+
     config.before_initialize do
     end
 


### PR DESCRIPTION
Add Google Analytics and Tag Manager page views + ecommerce integrations via presence of `GOOGLE_TAG_MANAGER_ID` and `GOOGLE_ANALYTICS_ID` environment variables.