### PR TITLE
Fixes DEPRECATION WARNING when using display_image

### DIFF
--- a/app/decorators/models/spree/product_decorator.rb
+++ b/app/decorators/models/spree/product_decorator.rb
@@ -17,10 +17,10 @@ module Spree
     end
 
     def seo_images
-      return [] unless display_image.attachment.file?
+      return [] unless gallery.images.any? && gallery.images.first.attachment.file?
 
       [
-        url_helper.image_url(display_image.attachment.url(:large), host: store_host),
+        url_helper.image_url(gallery.images.first.attachment.url(:large), host: store_host),
       ].compact
     end
 


### PR DESCRIPTION
There was a solidus deprecation warning when using display_image, its recommended to use `product.gallery` instead. Im also validating that a product could not have images at all.