### PR TITLE
Original google scripts

### DIFF
--- a/app/views/solidus_seo/_google-analytics.html.erb
+++ b/app/views/solidus_seo/_google-analytics.html.erb
@@ -25,16 +25,17 @@ if just_purchased
 end
 %>
 <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GOOGLE_ANALYTICS_ID'] %>"></script>
-<script type="text/javascript" data-tag="google-analytics">
-    window.dataLayer = window.dataLayer || [];
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-    function gtag(){ dataLayer.push(arguments); }
-
-    gtag('js', new Date());
-    gtag('config', '<%= ENV['GOOGLE_ANALYTICS_ID'] %>');
-
-    <% if just_purchased %>
-        gtag('event', 'purchase', <%== order_data.to_json %>);
-        window.solidusSeoDataLayer('google-analytics', 'purchase');
-    <% end %>
+  gtag('config', '<%= ENV['GOOGLE_ANALYTICS_ID'] %>');
 </script>
+
+<% if just_purchased %>
+  <script data-tag="google-analytics">
+    gtag('event', 'purchase', <%== order_data.to_json %>);
+    window.solidusSeoDataLayer('google-analytics', 'purchase');
+  </script>
+<% end %>

--- a/app/views/solidus_seo/_google-tag-manager.html.erb
+++ b/app/views/solidus_seo/_google-tag-manager.html.erb
@@ -2,49 +2,50 @@
 return if ENV['GOOGLE_ANALYTICS_ID'].present? || ENV['GOOGLE_TAG_MANAGER_ID'].blank?
 
 if just_purchased
-    order_data = {
-        id: order.number,
-        revenue: order.total,
-        coupon: '', # TODO: Add coupon code if present
+  order_data = {
+    id: order.number,
+    revenue: order.total,
+    coupon: '', # TODO: Add coupon code if present
 
-        affiliation: current_store.name,
-        currency: order.currency,
-        tax: order.tax_total,
-        shipping: order.ship_total
+    affiliation: current_store.name,
+    currency: order.currency,
+    tax: order.tax_total,
+    shipping: order.ship_total
+  }
+
+  purchased_items = order.line_items.map do |line_item|
+    next unless line_item.variant
+
+    {
+      id: line_item.variant.sku,
+      name: line_item.variant.name,
+      price: line_item.total,
+      variant: line_item.variant.options_text,
+      quantity: line_item.quantity
     }
-
-    purchased_items = order.line_items.map do |line_item|
-        next unless line_item.variant
-
-        {
-          id: line_item.variant.sku,
-          name: line_item.variant.name,
-          price: line_item.total,
-          variant: line_item.variant.options_text,
-          quantity: line_item.quantity
-        }
-    end.compact
+  end.compact
 end
 %>
 <script type="text/javascript" data-tag="google-tag-manager">
-    window.dataLayer = window.dataLayer || [];
+  window.dataLayer = window.dataLayer || [];
 
-    <% if just_purchased %>
-        window.dataLayer.push({
-            'ecommerce': {
-                'purchase': {
-                    'actionField': <%== order_data.to_json %>,
-                    'products': <%== purchased_items.to_json %>
-                }
-            }
-        });
+  <% if just_purchased %>
+    window.dataLayer.push({
+      'ecommerce': {
+        'purchase': {
+          'actionField': <%== order_data.to_json %>,
+          'products': <%== purchased_items.to_json %>
+        }
+      }
+    });
 
-        window.solidusSeoDataLayer('google-tag-manager', 'purchase');
-    <% end %>
-
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    window.solidusSeoDataLayer('google-tag-manager', 'purchase');
+  <% end %>
+</script>
+<script>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','<%= ENV['GOOGLE_TAG_MANAGER_ID'] %>');
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','<%= ENV['GOOGLE_TAG_MANAGER_ID'] %>');
 </script>

--- a/app/views/solidus_seo/_noscript_tags.html.erb
+++ b/app/views/solidus_seo/_noscript_tags.html.erb
@@ -1,0 +1,7 @@
+<%
+return if ENV['GOOGLE_TAG_MANAGER_ID'].blank?
+%>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= ENV['GOOGLE_TAG_MANAGER_ID'] %>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/lib/generators/solidus_seo/install/install_generator.rb
+++ b/lib/generators/solidus_seo/install/install_generator.rb
@@ -35,6 +35,7 @@ module SolidusSeo
           copy_file 'insert_product_list_helper.html.erb.deface', 'app/overrides/spree/shared/_products/insert_product_list_helper.html.erb.deface'
           copy_file 'insert_analytics_in_layout.html.erb.deface', 'app/overrides/spree/layouts/spree_application/insert_analytics_in_layout.html.erb.deface'
           copy_file 'replace_taxon_breadcrumbs_helper.html.erb.deface', 'app/overrides/spree/layouts/spree_application/replace_taxon_breadcrumbs_helper.html.erb.deface'
+          copy_file 'insert_noscript_tags.html.erb.deface', 'app/overrides/spree/layouts/spree_application/insert_noscript_tags.html.erb.deface'
         end
       end
     end

--- a/lib/generators/solidus_seo/install/templates/insert_noscript_tags.html.erb.deface
+++ b/lib/generators/solidus_seo/install/templates/insert_noscript_tags.html.erb.deface
@@ -1,0 +1,4 @@
+<!--
+insert_top "body"
+-->
+<%= render 'solidus_seo/noscript_tags' %>

--- a/lib/solidus_seo/jsonld/tag_helper.rb
+++ b/lib/solidus_seo/jsonld/tag_helper.rb
@@ -43,7 +43,7 @@ module SolidusSeo
       end
 
       def jsonld_fetch(type = :base, items = nil, opts = {})
-        force = opts.extract!(:force) || false
+        force = opts.delete(:force) || false
 
         jsonld_cache_key = [:jsonld, items, *opts.values].compact
 

--- a/lib/solidus_seo/version.rb
+++ b/lib/solidus_seo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusSeo
-  VERSION = '1.0.10'
+  VERSION = '1.0.11'
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -59,4 +59,19 @@ describe "Homepage", type: :system do
       expect(page).to have_css "meta[property='og:description'][content='#{seo_description}']", visible: false
     end
   end
+
+  context 'noscript tags' do
+    context 'when GOOGLE_TAG_MANAGER_ID is present' do
+      let(:env_variable) { 'GOOGLE_TAG_MANAGER_ID' }
+
+      before do
+        stub_const 'ENV', ENV.to_h.merge(env_variable => 'XXX-YYYYY')
+      end
+
+      it 'contains noscript tag for GTM' do
+        subject
+        expect(page).to have_text :all, "https://www.googletagmanager.com/ns.html"
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Fix warnings about "custom implementation" from google tag verification tools.
- Add `<noscript>` tag for google tag manager right after opening `<body>` tag. (All other providers already have their `<noscript>` tags right after the main script; they're supposed to appear in the header).
- Fix issue when retrieving :force option. Previous way always returned a truthy value: a hash with the option and whatever value was passed. Now just returns the value (boolean expected).