### PR TITLE
Track ViewContent and AddToCart events for FB pixel

### DIFF
--- a/app/views/solidus_seo/_facebook.html.erb
+++ b/app/views/solidus_seo/_facebook.html.erb
@@ -1,6 +1,10 @@
 <%
 return if ENV['FACEBOOK_PIXEL_ID'].blank?
 
+product_data = {}
+add_to_cart_data = {}
+order_data = {}
+
 if just_purchased
     order_data = {
         value: order.total,
@@ -20,6 +24,24 @@ if just_purchased
         promo_total: order.promo_total
     }
 end
+
+if flash[:added_to_cart].present?
+    add_to_cart_data = {
+        currency: order.currency,
+        content_type: 'product',
+        contents: flash[:added_to_cart].map do |variant_sku, variant|
+            { id: variant_sku, quantity: variant['quantity'] }
+        end
+    }
+end
+
+if @product
+    product_data = {
+        content_type: 'product',
+        content_name: @product.name,
+        content_ids: [@product.master.sku]
+    }
+end
 %>
 <script type="text/javascript" data-tag="facebook">
     !function(f,b,e,v,n,t,s) {if (f.fbq) return;n = f.fbq = function() { n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments) };if (!f._fbq) f._fbq=n;n.push = n; n.loaded = !0; n.version = '2.0'; n.queue=[]; t = b.createElement(e); t.async = !0; t.src = v;s = b.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t, s);}(window, document,'script', 'https://connect.facebook.net/en_US/fbevents.js');
@@ -27,9 +49,19 @@ end
     fbq('init', '<%= ENV['FACEBOOK_PIXEL_ID'] %>');
     fbq('track', 'PageView');
 
-    <% if just_purchased %>
+    <% if order_data.present? %>
         fbq('track', 'Purchase', <%== order_data.to_json %>);
         window.solidusSeoDataLayer('facebook', 'purchase');
+    <% end %>
+
+    <% if add_to_cart_data.present? %>
+        fbq('track', 'AddToCart', <%== add_to_cart_data.to_json %>);
+        window.solidusSeoDataLayer('facebook', 'addtocart');
+    <% end %>
+
+    <% if product_data.present? %>
+        fbq('track', 'ViewContent', <%== product_data.to_json %>);
+        window.solidusSeoDataLayer('facebook', 'productview');
     <% end %>
 </script>
 <noscript>

--- a/spec/features/add_to_cart_spec.rb
+++ b/spec/features/add_to_cart_spec.rb
@@ -15,6 +15,16 @@ describe 'Add to cart', type: :system do
     find('#add-to-cart-button').click
   end
 
+  context 'when FACEBOOK_PIXEL_ID environment variable is present' do
+    let(:env_variable) { 'FACEBOOK_PIXEL_ID' }
+
+    it 'tracks "add to cart" event with product data' do
+      expect(page).to track_analytics_event :facebook, 'addtocart', [
+        'fbq', 'track', 'AddToCart', line_item.sku
+      ]
+    end
+  end
+
   context 'when PINTEREST_TAG_ID environment variable is present' do
     let(:env_variable) { 'PINTEREST_TAG_ID' }
 

--- a/spec/features/checkout_complete_spec.rb
+++ b/spec/features/checkout_complete_spec.rb
@@ -19,7 +19,7 @@ describe 'Checkout complete', type: :system do
   context 'when GOOGLE_TAG_MANAGER_ID environment variable is present' do
     let(:env_variable) { 'GOOGLE_TAG_MANAGER_ID' }
 
-    it 'includes and executes a purchase event script' do
+    it 'tracks "purchase" event with product data' do
       subject
       expect(page).to track_analytics_event 'google-tag-manager', 'purchase', ['ecommerce', 'purchase', order.number, order.total, line_item.sku]
     end
@@ -28,7 +28,7 @@ describe 'Checkout complete', type: :system do
   context 'when GOOGLE_ANALYTICS_ID environment variable is present' do
     let(:env_variable) { 'GOOGLE_ANALYTICS_ID' }
 
-    it 'includes and executes a purchase event script' do
+    it 'tracks "purchase" event with product data' do
       subject
       expect(page).to track_analytics_event 'google-analytics', 'purchase', [
         'event', 'purchase', 'transaction_id', order.number,
@@ -41,7 +41,7 @@ describe 'Checkout complete', type: :system do
   context 'when FACEBOOK_PIXEL_ID environment variable is present' do
     let(:env_variable) { 'FACEBOOK_PIXEL_ID' }
 
-    it 'includes and executes a purchase event script' do
+    it 'tracks "Purchase" event with product data' do
       subject
       expect(page).to track_analytics_event :facebook, 'purchase', ['track', 'Purchase', order.total, line_item.sku, line_item.quantity, order.number]
     end
@@ -50,7 +50,7 @@ describe 'Checkout complete', type: :system do
   context 'when PINTEREST_TAG_ID environment variable is present' do
     let(:env_variable) { 'PINTEREST_TAG_ID' }
 
-    it 'includes and executes a purchase event script' do
+    it 'tracks "checkout" event with product data' do
       subject
       expect(page).to track_analytics_event :pinterest, 'purchase', ['track', 'checkout', order.total, line_item.sku, line_item.name, line_item.price]
     end

--- a/spec/features/product_page_spec.rb
+++ b/spec/features/product_page_spec.rb
@@ -97,6 +97,17 @@ describe "Product page", type: :system do
       stub_const 'ENV', ENV.to_h.merge(env_variable => 'XXX-YYYYY')
     end
 
+    context 'when FACEBOOK_PIXEL_ID environment variable is present' do
+      let(:env_variable) { 'FACEBOOK_PIXEL_ID' }
+
+      it 'tracks "ViewContent" event with product data' do
+        subject
+        expect(page).to track_analytics_event :facebook, 'productview', [
+          'fbq', 'track', 'ViewContent', product.name, product.master.sku
+        ]
+      end
+    end
+
     context 'when PINTEREST_TAG_ID environment variable is present' do
       let(:env_variable) { 'PINTEREST_TAG_ID' }
 


### PR DESCRIPTION
[Task #765](https://trello.com/c/HwncKZdi/765-add-or-configure-facebook-additional-events-for-view-content-add-to-cart-initiate-checkout-and-purchase)

Add tracking of `ViewContent` and `AddToCart` events for facebook pixel.