### PR TITLE
Fix displaying of `added_to_cart` flash message

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Here are the changes we make, via deface, in the default Solidus views as part o
   - Insert `<%= render 'solidus_seo/noscript_tags' %>` immediately after the `<body>` opening tag.
   - Insert `<%= dump_jsonld %>` just before the `</body>` closing tag.
   - Replace `<%= taxon_breadcrumbs(@taxon) %>` with (`<%= taxon_breadcrumbs_jsonld(@taxon) %>`) which does the same as the original plus prints a JSON-LD tag.
+  - Replace `<%= flash_messages %>` with (`<%= flash_messages(ignore_types: 'added_to_cart') %>`) which does the same as the original plus prints a JSON-LD tag.
 
 - In `spree/products/show.html.erb`:
   - Insert `<%= jsonld @product %>` anywhere inside the `cache` block.

--- a/lib/generators/solidus_seo/install/install_generator.rb
+++ b/lib/generators/solidus_seo/install/install_generator.rb
@@ -36,6 +36,7 @@ module SolidusSeo
           copy_file 'insert_analytics_in_layout.html.erb.deface', 'app/overrides/spree/layouts/spree_application/insert_analytics_in_layout.html.erb.deface'
           copy_file 'replace_taxon_breadcrumbs_helper.html.erb.deface', 'app/overrides/spree/layouts/spree_application/replace_taxon_breadcrumbs_helper.html.erb.deface'
           copy_file 'insert_noscript_tags.html.erb.deface', 'app/overrides/spree/layouts/spree_application/insert_noscript_tags.html.erb.deface'
+          copy_file 'replace_flash_messages_helper.html.erb.deface', 'app/overrides/spree/layouts/spree_application/replace_flash_messages_helper.html.erb.deface'
         end
       end
     end

--- a/lib/generators/solidus_seo/install/templates/replace_flash_messages_helper.html.erb.deface
+++ b/lib/generators/solidus_seo/install/templates/replace_flash_messages_helper.html.erb.deface
@@ -1,0 +1,5 @@
+<!--
+replace %{erb[loud]:contains("flash_messages")}
+original "<%= flash_messages %>"
+-->
+<%= flash_messages(ignore_types: 'added_to_cart') %>

--- a/spec/features/add_to_cart_spec.rb
+++ b/spec/features/add_to_cart_spec.rb
@@ -24,6 +24,10 @@ describe 'Add to cart', type: :system do
         line_item.name, line_item.variant.sku, line_item.variant.price
       ]
     end
+
+    it 'skips printing a flash message to the user with added_to_cart raw data' do
+      expect(page).to_not have_css '.flash.added_to_cart'
+    end
   end
 end
 


### PR DESCRIPTION
We use flash data under the `added_to_cart` key to store a hash with product data updated in the previous request but it's not intended to be shown as an actual message. Turns out solidus automatically prints all flash data to the frontend unless they're filtered out using the `ignore_types` option of the `flash_messages` helper.