### PR TITLE
Add order presence guards for snippets

### DIFF
--- a/app/views/solidus_seo/_facebook.html.erb
+++ b/app/views/solidus_seo/_facebook.html.erb
@@ -3,42 +3,44 @@ return if ENV['FACEBOOK_PIXEL_ID'].blank?
 
 event_data = {}
 
-if just_purchased
-    event_data[:order] = {
-        value: order.total,
-        currency: order.currency,
-        content_type: 'product',
-        contents: order.line_items.map do |line_item|
-            { id: line_item.variant.sku, quantity: line_item.quantity }
-        end,
+if order.present?
+    if just_purchased
+        event_data[:order] = {
+            value: order.total,
+            currency: order.currency,
+            content_type: 'product',
+            contents: order.line_items.map do |line_item|
+                { id: line_item.variant.sku, quantity: line_item.quantity }
+            end,
 
-        # custom properties
-        order_number: order.number,
-        item_total: order.item_total,
-        tax_total: order.tax_total,
-        ship_total: order.ship_total,
-        promo_total: order.promo_total
-    }
-end
+            # custom properties
+            order_number: order.number,
+            item_total: order.item_total,
+            tax_total: order.tax_total,
+            ship_total: order.ship_total,
+            promo_total: order.promo_total
+        }
+    end
 
-if flash[:added_to_cart].present?
-    event_data[:added_to_cart] = {
-        currency: order.currency,
-        content_type: 'product',
-        contents: flash[:added_to_cart].map do |variant_sku, variant|
-            { id: variant_sku, quantity: variant['quantity'] }
-        end
-    }
-end
+    if flash[:added_to_cart].present?
+        event_data[:added_to_cart] = {
+            currency: order.currency,
+            content_type: 'product',
+            contents: flash[:added_to_cart].map do |variant_sku, variant|
+                { id: variant_sku, quantity: variant['quantity'] }
+            end
+        }
+    end
 
-if flash[:checkout_initiated].present?
-    event_data[:checkout] = {
-        value: order.total,
-        currency: order.currency,
-        contents: order.line_items.map do |line_item|
-            { id: line_item.variant.sku, quantity: line_item.quantity }
-        end
-    }
+    if flash[:checkout_initiated].present?
+        event_data[:checkout_initiated] = {
+            value: order.total,
+            currency: order.currency,
+            contents: order.line_items.map do |line_item|
+                { id: line_item.variant.sku, quantity: line_item.quantity }
+            end
+        }
+    end
 end
 
 if @product
@@ -66,8 +68,8 @@ end
         window.solidusSeoDataLayer('facebook', 'addtocart');
     <% end %>
 
-    <% if event_data[:checkout].present? %>
-        fbq('track', 'InitiateCheckout', <%== event_data[:checkout].to_json %>);
+    <% if event_data[:checkout_initiated].present? %>
+        fbq('track', 'InitiateCheckout', <%== event_data[:checkout_initiated].to_json %>);
         window.solidusSeoDataLayer('facebook', 'initiatecheckout');
     <% end %>
 

--- a/app/views/solidus_seo/_google-analytics.html.erb
+++ b/app/views/solidus_seo/_google-analytics.html.erb
@@ -1,8 +1,10 @@
 <%
 return if ENV['GOOGLE_TAG_MANAGER_ID'].present? || ENV['GOOGLE_ANALYTICS_ID'].blank?
 
+event_data = {}
+
 if just_purchased
-    order_data = {
+    event_data[:order] = {
         transaction_id: order.number,
         value: order.total,
         items: order.line_items.map do |line_item|
@@ -33,7 +35,7 @@ end
 
 <% if just_purchased %>
   <script data-tag="google-analytics">
-    gtag('event', 'purchase', <%== order_data.to_json %>);
+    gtag('event', 'purchase', <%== event_data[:order].to_json %>);
     window.solidusSeoDataLayer('google-analytics', 'purchase');
   </script>
 <% end %>

--- a/app/views/solidus_seo/_google-tag-manager.html.erb
+++ b/app/views/solidus_seo/_google-tag-manager.html.erb
@@ -1,8 +1,10 @@
 <%
 return if ENV['GOOGLE_ANALYTICS_ID'].present? || ENV['GOOGLE_TAG_MANAGER_ID'].blank?
 
+event_data = {}
+
 if just_purchased
-    order_data = {
+    event_data[:order] = {
         id: order.number,
         revenue: order.total,
         coupon: '', # TODO: Add coupon code if present
@@ -13,7 +15,7 @@ if just_purchased
         shipping: order.ship_total
     }
 
-    purchased_items = order.line_items.map do |line_item|
+    event_data[:order_contents] = order.line_items.map do |line_item|
         {
           id: line_item.variant.sku,
           name: line_item.variant.name,
@@ -31,8 +33,8 @@ end
     window.dataLayer.push({
       'ecommerce': {
         'purchase': {
-          'actionField': <%== order_data.to_json %>,
-          'products': <%== purchased_items.to_json %>
+          'actionField': <%== event_data[:order].to_json %>,
+          'products': <%== event_data[:order_contents].to_json %>
         }
       }
     });

--- a/app/views/solidus_seo/_google-tag-manager.html.erb
+++ b/app/views/solidus_seo/_google-tag-manager.html.erb
@@ -7,7 +7,7 @@ if just_purchased
     event_data[:order] = {
         id: order.number,
         revenue: order.total,
-        coupon: '', # TODO: Add coupon code if present
+        coupon: order.adjustments.promotion.first&.promotion_code&.value,
 
         affiliation: current_store.name,
         currency: order.currency,

--- a/app/views/solidus_seo/_pinterest.html.erb
+++ b/app/views/solidus_seo/_pinterest.html.erb
@@ -8,24 +8,44 @@ if user_email.present?
     em_data = { em: user_email }
 end
 
-if just_purchased
-    event_data[:order] = {
-        value: order.total,
-        currency: order.currency,
-        order_quantity: order.line_items.sum(&:quantity),
-        line_items: order.line_items.map do |line_item|
-            next unless line_item.variant
+if order.present?
+    if just_purchased
+        event_data[:order] = {
+            value: order.total,
+            currency: order.currency,
+            order_quantity: order.line_items.sum(&:quantity),
+            line_items: order.line_items.map do |line_item|
+                next unless line_item.variant
 
-            {
-                product_id: line_item.variant.product.master.sku,
-                product_name: line_item.variant.name,
-                product_variant_id: line_item.variant.sku,
-                product_variant: line_item.variant.options_text,
-                product_quantity: line_item.quantity,
-                product_price: line_item.price
-            }
-        end.compact
-    }
+                {
+                    product_id: line_item.variant.product.master.sku,
+                    product_name: line_item.variant.name,
+                    product_variant_id: line_item.variant.sku,
+                    product_variant: line_item.variant.options_text,
+                    product_quantity: line_item.quantity,
+                    product_price: line_item.price
+                }
+            end.compact
+        }
+    end
+
+    if flash[:added_to_cart].present?
+        event_data[:added_to_cart] = {
+            value: order.total,
+            currency: order.currency,
+            order_id: order.number,
+            line_items: flash[:added_to_cart].map do |variant_sku, variant|
+                {
+                    product_id: variant['id'],
+                    product_name: variant['name'],
+                    product_variant_id: variant_sku,
+                    product_variant: variant['variant'],
+                    product_price: variant['price'],
+                    product_quantity: variant['quantity']
+                }
+            end
+        }
+    end
 end
 
 if @product
@@ -39,23 +59,7 @@ if @product
     }
 end
 
-if flash[:added_to_cart].present?
-    event_data[:added_to_cart] = {
-        value: order.total,
-        currency: order.currency,
-        order_id: order.number,
-        line_items: flash[:added_to_cart].map do |variant_sku, variant|
-            {
-                product_id: variant['id'],
-                product_name: variant['name'],
-                product_variant_id: variant_sku,
-                product_variant: variant['variant'],
-                product_price: variant['price'],
-                product_quantity: variant['quantity']
-            }
-        end
-    }
-end
+
 %>
 <script type="text/javascript" data-tag="pinterest">
     !function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version="3.0";var t=document.createElement("script");t.async=!0,t.src=e;var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r)}}("https://s.pinimg.com/ct/core.js");

--- a/lib/solidus_seo/version.rb
+++ b/lib/solidus_seo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusSeo
-  VERSION = '1.0.13'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
- Add guards for order presence. We detected an issue with some flash messages that are persisted in multiple requests and that's causing some pages to break when the @order variable is not present.
- Normalizes the structure of the data used in the snippets (preparing to extend event detection in other providers).
- Implements coupon detection for Google Tag Manager provider.