### PR TITLE
Add content_type data to FB pixel's InitiateCheckout event

### DIFF
--- a/app/views/solidus_seo/_facebook.html.erb
+++ b/app/views/solidus_seo/_facebook.html.erb
@@ -36,6 +36,7 @@ if order.present?
         event_data[:checkout_initiated] = {
             value: order.total,
             currency: order.currency,
+            content_type: 'product',
             contents: order.line_items.map do |line_item|
                 { id: line_item.variant.sku, quantity: line_item.quantity }
             end


### PR DESCRIPTION
Facebook pixel integration doesn't mention support for the `content_type` parameter for the InitiateCheckout event but there are reports of warnings of missing data for that parameter in FB's event management dashboard.

This change should fix that issue.

![image](https://user-images.githubusercontent.com/34167503/127249774-82fad2c1-3463-4bc4-9969-386aedb0230d.png)
![image](https://user-images.githubusercontent.com/34167503/127250195-38e59dfc-81db-46b3-958f-44116d979d0f.png)

PS. Originally merged in https://github.com/karmakatahdin/solidus_seo/pull/25 but somehow it's not on master (?!)