### PR TITLE
Report value for AddToCart events

### DIFF
--- a/app/decorators/controllers/spree/orders_controller_decorator.rb
+++ b/app/decorators/controllers/spree/orders_controller_decorator.rb
@@ -26,6 +26,7 @@ module Spree
       cart_diff = cart_diff.map do |variant_sku, quantity|
         variant_hash = cart_diff_variant_payload(variant_sku)
         variant_hash[:quantity] = quantity
+        variant_hash[:amount] = quantity * variant_hash[:price]
 
         [variant_sku, variant_hash]
       end.to_h

--- a/app/views/solidus_seo/_facebook.html.erb
+++ b/app/views/solidus_seo/_facebook.html.erb
@@ -24,6 +24,7 @@ if order.present?
 
     if flash[:added_to_cart].present?
         event_data[:added_to_cart] = {
+            value: flash[:added_to_cart].sum { |sku, hash| hash['amount'].to_d },
             currency: order.currency,
             content_type: 'product',
             contents: flash[:added_to_cart].map do |variant_sku, variant|

--- a/app/views/solidus_seo/_pinterest.html.erb
+++ b/app/views/solidus_seo/_pinterest.html.erb
@@ -31,7 +31,7 @@ if order.present?
 
     if flash[:added_to_cart].present?
         event_data[:added_to_cart] = {
-            value: order.total,
+            value: flash[:added_to_cart].sum { |sku, hash| hash['amount'].to_d },
             currency: order.currency,
             order_id: order.number,
             line_items: flash[:added_to_cart].map do |variant_sku, variant|

--- a/lib/solidus_seo/version.rb
+++ b/lib/solidus_seo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusSeo
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end

--- a/spec/features/add_to_cart_spec.rb
+++ b/spec/features/add_to_cart_spec.rb
@@ -2,16 +2,18 @@
 
 describe 'Add to cart', type: :system do
   let!(:store) { create(:store) }
-  let!(:order) { create :completed_order_with_totals }
-  let!(:line_item) { order.line_items.first }
+  let!(:product) { create(:product) }
+  let(:line_item_quantity) { 2 }
+  let(:order) { Spree::Order.last }
+  let(:line_item) { order.line_items.first }
 
   stub_authorization!
 
   before do
-    current_order_stubs(order)
     stub_const 'ENV', ENV.to_h.merge(env_variable => 'XXX-YYYYY')
 
-    visit spree.product_path(line_item.product)
+    visit spree.product_path(product)
+    fill_in('quantity', with: line_item_quantity)
     find('#add-to-cart-button').click
   end
 
@@ -20,7 +22,7 @@ describe 'Add to cart', type: :system do
 
     it 'tracks "add to cart" event with product data' do
       expect(page).to track_analytics_event :facebook, 'addtocart', [
-        'fbq', 'track', 'AddToCart', line_item.sku
+        'fbq', 'track', 'AddToCart', line_item.amount, line_item.sku
       ]
     end
   end
@@ -30,8 +32,8 @@ describe 'Add to cart', type: :system do
 
     it 'tracks "add to cart" event' do
       expect(page).to track_analytics_event :pinterest, 'addtocart', [
-        'track', 'addtocart', order.total, order.number, line_item.variant.product.master.sku,
-        line_item.name, line_item.variant.sku, line_item.variant.price
+        'track', 'addtocart', line_item.amount, order.number, line_item.product.sku,
+        line_item.name, line_item.sku, line_item.price
       ]
     end
 


### PR DESCRIPTION
- Add `value` property to facebook pixel's AddToCart event.
- Fix `value` property of pinterest's AddToCart event to refer to added item total instead of new order total.